### PR TITLE
Avoid using connection strings with psql, correctly extract tenant_id

### DIFF
--- a/postgresql/ad_roles.tf
+++ b/postgresql/ad_roles.tf
@@ -82,11 +82,11 @@ output "ad_setup_config" {
     ad_roles_setup_script  = local.ad_roles_setup
     ad_grants_setup_script = local.ad_grants_setup
     config = {
-      libpg_base_connection_string = "postgresql://${azurerm_postgresql_flexible_server.main.fqdn}/?sslmode=require"
-      administrator_login          = azurerm_postgresql_flexible_server.main.administrator_login
-      administrator_password       = azurerm_postgresql_flexible_server.main.administrator_password
-      ad_administrator_login       = azurerm_postgresql_flexible_server_active_directory_administrator.admin.principal_name
-      tenant_id                    = azurerm_postgresql_flexible_server_active_directory_administrator.admin.tenant_id
+      fqdn                   = azurerm_postgresql_flexible_server.main.fqdn
+      administrator_login    = azurerm_postgresql_flexible_server.main.administrator_login
+      administrator_password = azurerm_postgresql_flexible_server.main.administrator_password
+      ad_administrator_login = azurerm_postgresql_flexible_server_active_directory_administrator.admin.principal_name
+      tenant_id              = azurerm_postgresql_flexible_server_active_directory_administrator.admin.tenant_id
     }
   }
 }

--- a/postgresql/provision_psql.sh
+++ b/postgresql/provision_psql.sh
@@ -4,21 +4,24 @@ set -e
 postgres_config_output_name=${1:-postgres_ad_roles_config}
 config=$(terraform output -json "$postgres_config_output_name")
 
-libpg_base_connection_string=$(jq -r '.config.libpg_base_connection_string' <<< "$config")
+fqdn=$(jq -r '.config.fqdn' <<< "$config")
 administrator_login=$(jq -r '.config.administrator_login' <<< "$config")
 administrator_password=$(jq -r '.config.administrator_password' <<< "$config")
 ad_administrator_login=$(jq -r '.config.ad_administrator_login' <<< "$config")
+tenant_id=$(jq -r '.config.tenant_id' <<< "$config")
 setup_roles=$(jq -r  ".ad_roles_setup_script" <<< "$config")
 setup_grants=$(jq -r  ".ad_grants_setup_script" <<< "$config")
 
 ad_admin_token=$(az account get-access-token -t "${tenant_id}" --resource-type oss-rdbms --query accessToken -o tsv)
 
+export PGHOST="${fqdn}"
 export PGDATABASE='postgres'
 export PGUSER="${ad_administrator_login}"
 export PGPASSWORD="${ad_admin_token}"
 
-psql "${libpg_base_connection_string}" <<< "$setup_roles"
+psql -h "${PGHOST}" -U "${PGUSER}" -d "${PGDATABASE}" <<< "${setup_roles}"
 
 export PGUSER="${administrator_login}"
 export PGPASSWORD="${administrator_password}"
-psql "${libpg_base_connection_string}" <<< "$setup_grants"
+
+psql -h "${PGHOST}" -U "${PGUSER}" -d "${PGDATABASE}" <<< "${setup_grants}"


### PR DESCRIPTION
Using connection strings sometimes causes issues like

```
psql: error: connection to server at … failed: FATAL:  no PostgreSQL user name specified in startup packet
double free or corruption (out)
Aborted                 (core dumped)
```

… no matter if the username was passed in the connection string itself or using `PGUSER`, which I imagine could be caused by having whitespace characters in them. Using `-U "${PGUSER}"` fixes it so let's go with that.

Also fix `tenant_id` being undefined.