### PR TITLE
Add storage_account_access_key to azure_blob_storage outputs

### DIFF
--- a/azure_blob_storage/outputs.tf
+++ b/azure_blob_storage/outputs.tf
@@ -14,6 +14,10 @@ output "storage_connection_string" {
   value = azurerm_storage_account.storage.primary_blob_connection_string
 }
 
+output "storage_account_access_key" {
+  value = azurerm_storage_account.storage.primary_access_key
+}
+
 output "storage_containers" {
   value = azurerm_storage_container.containers
 }


### PR DESCRIPTION
I need key only in order to create `function_app` resource