### PR TITLE
Fix blob cors rules

### DIFF
--- a/azure_blob_storage/main.tf
+++ b/azure_blob_storage/main.tf
@@ -34,11 +34,11 @@ resource "azurerm_storage_account" "storage" {
     dynamic "cors_rule" {
       for_each = var.blob_cors_rules
       content {
-        allowed_headers    = each.value.allowed_headers
-        allowed_methods    = each.value.allowed_methods
-        allowed_origins    = each.value.allowed_origins
-        exposed_headers    = each.value.exposed_headers
-        max_age_in_seconds = each.value.max_age_in_seconds
+        allowed_headers    = cors_rule.value.allowed_headers
+        allowed_methods    = cors_rule.value.allowed_methods
+        allowed_origins    = cors_rule.value.allowed_origins
+        exposed_headers    = cors_rule.value.exposed_headers
+        max_age_in_seconds = cors_rule.value.max_age_in_seconds
       }
     }
 


### PR DESCRIPTION
When added in develia (so that web can upload files):
```
  blob_cors_rules = [
    {
      allowed_origins    = ["*"]
      allowed_methods    = ["GET", "PUT"]
      allowed_headers    = ["*"]
      exposed_headers    = ["*"]
      max_age_in_seconds = 3600
    }
  ]
```

I kept getting:
```
│ Error: each.value cannot be used in this context
│ 
│   on .terraform/modules/app.storage/azure_blob_storage/main.tf line 39, in resource "azurerm_storage_account" "storage":
│   39:         allowed_origins    = each.value.allowed_origins
│ 
│ A reference to "each.value" has been used in a context in which it is unavailable, such as when the configuration no longer contains the value in its "for_each"
│ expression. Remove this reference to each.value in your configuration to work around this error.
```

Also how this should be tagged once merged `v0.3.1`?