### PR TITLE
Use non-deprecated way of referencing azure storage from container

### DIFF
--- a/azure_blob_storage/main.tf
+++ b/azure_blob_storage/main.tf
@@ -61,7 +61,7 @@ resource "azurerm_storage_account" "storage" {
 resource "azurerm_storage_container" "containers" {
   for_each = var.blob_containers
 
-  storage_account_name = azurerm_storage_account.storage.name
+  storage_account_id = azurerm_storage_account.storage.id
 
   name                  = each.key
   container_access_type = each.value.access_type #tfsec:ignore:azure-storage-no-public-access


### PR DESCRIPTION
Could I tag this as `v0.3.2`?