### PR TITLE
Switch and bump ArgoCD provider source

### DIFF
--- a/argocd_app/main.tf
+++ b/argocd_app/main.tf
@@ -3,8 +3,8 @@ terraform {
 
   required_providers {
     argocd = {
-      source  = "oboukili/argocd"
-      version = "~> 6.1"
+      source  = "argoproj-labs/argocd"
+      version = "~> 7.3"
     }
   }
 }


### PR DESCRIPTION
Since provider release 7.2 it officially supports ArgoCD 2.12 (which is present in our infrastructure), so just bumping this provider should be enough.

Closes CORELIB-190