### PR TITLE
Disable SQL Server public network access basing on firewall rules

### DIFF
--- a/mssql_server/mssql_server.tf
+++ b/mssql_server/mssql_server.tf
@@ -20,7 +20,8 @@ resource "azurerm_mssql_server" "main" {
   administrator_login          = var.sa_login
   administrator_login_password = random_password.db_sa.result
 
-  minimum_tls_version = "1.2"
+  public_network_access_enabled = var.firewall.allow_all
+  minimum_tls_version           = "1.2"
 
   azuread_administrator {
     tenant_id      = var.ad_admin.tenant_id


### PR DESCRIPTION
Kinda weird that it was left on default (`true`) at all times?