### PR TITLE
Enable overriding SQL Server db storage account type

### DIFF
--- a/mssql_server/databases.tf
+++ b/mssql_server/databases.tf
@@ -3,9 +3,10 @@ resource "azurerm_mssql_database" "databases" {
 
   server_id = azurerm_mssql_server.main.id
 
-  name      = each.key
-  sku_name  = each.value.sku
-  collation = each.value.collation
+  name                 = each.key
+  sku_name             = each.value.sku
+  collation            = each.value.collation
+  storage_account_type = each.value.storage_account_type
 
   tags = var.tags
 }

--- a/mssql_server/variables.tf
+++ b/mssql_server/variables.tf
@@ -40,8 +40,9 @@ variable "firewall" {
 
 variable "databases" {
   type = map(object({
-    sku       = string
-    collation = string
+    sku                  = string
+    collation            = string
+    storage_account_type = optional(string, "Geo")
   }))
 }
 


### PR DESCRIPTION
As of now it's impossible to apply this module for MS SQL servers in regions where default storage account type (`Geo`) is unavailable.