### PR TITLE
Allow specifying SQL Server DB permissions for users

### DIFF
--- a/mssql_database_user/outputs.tf
+++ b/mssql_database_user/outputs.tf
@@ -7,3 +7,7 @@ output "managed_identity_connection_string" {
     "Authentication=Active Directory Default",
   ])
 }
+
+output "db_user_id" {
+  value = mssql_azuread_service_principal.user.id
+}

--- a/mssql_database_user/user_roles.tf
+++ b/mssql_database_user/user_roles.tf
@@ -11,3 +11,10 @@ resource "mssql_database_role_member" "roles" {
   role_id   = each.key
   member_id = mssql_azuread_service_principal.user.id
 }
+
+resource "mssql_database_permission" "permissions" {
+  for_each = var.permissions
+
+  permission   = each.key
+  principal_id = mssql_azuread_service_principal.user.id
+}

--- a/mssql_database_user/variables.tf
+++ b/mssql_database_user/variables.tf
@@ -15,3 +15,8 @@ variable "user" {
 variable "roles" {
   type = set(string)
 }
+
+variable "permissions" {
+  type    = set(string)
+  default = []
+}


### PR DESCRIPTION
I need `EXECUTE` permission for using a TVP.

Also added DB user ID on the output, so the next person doesn't necessarily have to patch this module when they need something non-standard.